### PR TITLE
Add actor remotes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 derivative = "1.0.3"
 futures-preview = { version = "0.3.0-alpha.18", features = ["async-await", "nightly"] }
 log = "0.4.8"
-num-derive = "0.2.5"
+num_enum = "0.4.1"
 thespian-derive = { path = "./thespian-derive" }
 runtime = "0.3.0-alpha.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 derivative = "1.0.3"
 futures-preview = { version = "0.3.0-alpha.18", features = ["async-await", "nightly"] }
 log = "0.4.8"
+num-derive = "0.2.5"
 thespian-derive = { path = "./thespian-derive" }
 runtime = "0.3.0-alpha.7"
 

--- a/examples/remote.rs
+++ b/examples/remote.rs
@@ -1,0 +1,50 @@
+use runtime::time::*;
+use std::time::Duration;
+use thespian::*;
+
+#[runtime::main]
+async fn main() {
+    let (builder, remote) = StageBuilder::new();
+    let actor = MyActor { remote, count: 0 };
+    let stage = builder.finish(actor);
+    let mut actor = stage.proxy();
+    runtime::spawn(stage.run());
+
+    // Use the handle to call the `add_count` method. Under the hood, this is using
+    // channels and message passing to communicate between tasks/threads, but
+    // thespian hides those implementation details and provides a simple, await-aware
+    // way to communicate with the actor.
+    for _ in 0..10 {
+        let id = actor
+            .add_count(1)
+            .await
+            .expect("Failed to invoke `add_id` on actor");
+        println!("New count: {}", id);
+    }
+}
+
+// Actors are defined as normal structs.
+#[derive(Debug)]
+pub struct MyActor {
+    remote: Remote<Self>,
+    count: usize,
+}
+
+// To define messages for an actor, mark an impl bloc with the `thespian::actor`
+// attribute. All methods defined in this impl block become messages that can be
+// sent via the generated actor handle.
+#[thespian::actor]
+impl MyActor {
+    /// Adds to the actor's count, simulating a slow operation such as writing to a
+    /// database.
+    pub async fn add_count(&mut self, value: usize) -> usize {
+        Delay::new(Duration::from_secs(1)).await;
+        self.count += value;
+
+        if self.count >= 10 {
+            let _ = self.remote.stop();
+        }
+
+        self.count
+    }
+}

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -14,7 +14,6 @@ use std::fmt;
 pub(crate) enum Envelope<A: Actor> {
     Sync(Box<dyn SyncErasedMessage<A>>),
     Async(Box<dyn AsyncErasedMessage<A>>),
-    Stop,
     ProxyDropped,
 }
 
@@ -23,7 +22,6 @@ impl<A: Actor> fmt::Debug for Envelope<A> {
         match self {
             Envelope::Sync(..) => write!(f, "Envelope::Sync"),
             Envelope::Async(..) => write!(f, "Envelope::Async"),
-            Envelope::Stop => write!(f, "Envelope::Stop"),
             Envelope::ProxyDropped => write!(f, "Envelope::ProxyDropped"),
         }
     }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -15,6 +15,7 @@ pub(crate) enum Envelope<A: Actor> {
     Sync(Box<dyn SyncErasedMessage<A>>),
     Async(Box<dyn AsyncErasedMessage<A>>),
     Stop,
+    ProxyDropped,
 }
 
 impl<A: Actor> fmt::Debug for Envelope<A> {
@@ -23,6 +24,7 @@ impl<A: Actor> fmt::Debug for Envelope<A> {
             Envelope::Sync(..) => write!(f, "Envelope::Sync"),
             Envelope::Async(..) => write!(f, "Envelope::Async"),
             Envelope::Stop => write!(f, "Envelope::Stop"),
+            Envelope::ProxyDropped => write!(f, "Envelope::ProxyDropped"),
         }
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -14,13 +14,15 @@ use std::fmt;
 pub(crate) enum Envelope<A: Actor> {
     Sync(Box<dyn SyncErasedMessage<A>>),
     Async(Box<dyn AsyncErasedMessage<A>>),
+    Stop,
 }
 
 impl<A: Actor> fmt::Debug for Envelope<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Envelope::Sync(..) => write!(f, "Envelope::Sync"),
-            Envelope::Async(..) => write!(f, "Evenlope::Async"),
+            Envelope::Async(..) => write!(f, "Envelope::Async"),
+            Envelope::Stop => write!(f, "Envelope::Stop"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use std::sync::{atomic::AtomicU8, Arc};
 
 mod envelope;
 mod message;
+mod remote;
 mod stage;
 
 pub use crate::message::*;
@@ -19,12 +20,6 @@ pub trait Actor: 'static + Sized + Send {
 
     fn into_stage(self) -> (Self::Proxy, Stage<Self>) {
         // TODO: Make the channel buffer configurable.
-        let (sender, receiver) = mpsc::channel(16);
-        let remote_inner = Arc::new(RemoteInner::new(ActorState::Built));
-        let proxy = Self::Proxy::new(ProxyFor {
-            sink: sender,
-            proxy_count: Arc::new(()),
-        });
 
         let stage = Stage {
             actor: self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,11 @@ use log::*;
 
 mod envelope;
 mod message;
+mod proxy;
 mod remote;
 mod stage;
 
-pub use crate::{message::*, remote::Remote};
+pub use crate::{message::*, proxy::*, remote::Remote};
 pub use thespian_derive::actor;
 
 pub trait Actor: 'static + Sized + Send {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-use crate::stage::*;
 use futures::channel::{mpsc, oneshot};
 use log::*;
 
@@ -8,7 +7,7 @@ mod proxy;
 mod remote;
 mod stage;
 
-pub use crate::{message::*, proxy::*, remote::Remote};
+pub use crate::{message::*, proxy::*, remote::*, stage::*};
 pub use thespian_derive::actor;
 
 pub trait Actor: 'static + Sized + Send {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,0 +1,124 @@
+use crate::{envelope::*, message::*, Actor, MessageError};
+use derivative::Derivative;
+use futures::{
+    channel::{mpsc, oneshot},
+    prelude::*,
+};
+use std::{
+    mem,
+    sync::{Arc, Weak},
+};
+
+pub(crate) type EnvelopeSender<A> = mpsc::Sender<Envelope<A>>;
+
+pub trait ActorProxy: Sized + Clone {
+    type Actor: Actor<Proxy = Self>;
+
+    fn new(inner: ProxyFor<Self::Actor>) -> Self;
+}
+
+#[derive(Derivative)]
+#[derivative(Debug(bound = ""), Clone(bound = ""))]
+pub struct ProxyFor<A: Actor> {
+    sink: EnvelopeSender<A>,
+
+    // NOTE: We wrap the ref count in an `Option` in order to control the drop order.
+    // On drop, we send a message to the stage, but we need to ensure that the ref
+    // count has been decremented before the message is received. Wrapping it in an
+    // `Option` means we can `take` the value to drop it early. The proxy count will
+    // always have a value outside of the destructor, so it's safe to unwrap.
+    proxy_count: Option<Arc<()>>,
+}
+
+impl<A: Actor> ProxyFor<A> {
+    pub(crate) fn new(sink: EnvelopeSender<A>) -> Self {
+        Self {
+            sink,
+            proxy_count: Some(Arc::new(())),
+        }
+    }
+
+    pub async fn send_sync<M: SyncMessage<Actor = A>>(
+        &mut self,
+        message: M,
+    ) -> Result<M::Result, MessageError> {
+        let (result_sender, result) = oneshot::channel();
+        let erased_message = Box::new(SyncEnvelope {
+            message,
+            result_sender,
+        });
+        let envelope = Envelope::Sync(erased_message);
+        self.sink
+            .send(envelope)
+            .await
+            .map_err::<MessageError, _>(Into::into)?;
+        result.await.map_err(Into::into)
+    }
+
+    pub async fn send_async<M: AsyncMessage<Actor = A>>(
+        &mut self,
+        message: M,
+    ) -> Result<M::Result, MessageError> {
+        let (result_sender, result) = oneshot::channel();
+        let erased_message = Box::new(AsyncEnvelope {
+            message,
+            result_sender,
+        });
+        let envelope = Envelope::Async(erased_message);
+        self.sink
+            .send(envelope)
+            .await
+            .map_err::<MessageError, _>(Into::into)?;
+        result.await.map_err(Into::into)
+    }
+
+    pub async fn stop(&mut self) -> Result<(), MessageError> {
+        self.sink
+            .send(Envelope::Stop)
+            .await
+            .map_err::<MessageError, _>(Into::into)
+    }
+
+    pub(crate) fn count(&self) -> usize {
+        Arc::strong_count(self.proxy_count.as_ref().unwrap())
+    }
+
+    pub(crate) fn downgrade(&self) -> WeakProxyFor<A> {
+        WeakProxyFor {
+            sink: self.sink.clone(),
+            proxy_count: Arc::downgrade(self.proxy_count.as_ref().unwrap()),
+        }
+    }
+}
+
+impl<A: Actor> Drop for ProxyFor<A> {
+    fn drop(&mut self) {
+        // Manaully drop the inner ref count in order to ensure the count has decreased
+        // *before* the stage receives the drop message.
+        mem::drop(self.proxy_count.take());
+
+        // Send the drop message so that the stage can stop itself if there are no
+        // proxies left.
+        //
+        // NOTE: We don't care if the message send fails here in the case that the buffer
+        // is full. If that happens, the stage will check the proxy count after processing
+        // the next message to see if there are any proxies left.
+        let _ = self.sink.try_send(Envelope::ProxyDropped);
+    }
+}
+
+#[derive(Derivative)]
+#[derivative(Debug(bound = ""))]
+pub(crate) struct WeakProxyFor<A: Actor> {
+    sink: EnvelopeSender<A>,
+    proxy_count: Weak<()>,
+}
+
+impl<A: Actor> WeakProxyFor<A> {
+    pub(crate) fn upgrade(&self) -> Option<ProxyFor<A>> {
+        self.proxy_count.upgrade().map(|proxy_count| ProxyFor {
+            sink: self.sink.clone(),
+            proxy_count: Some(proxy_count),
+        })
+    }
+}

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -72,13 +72,6 @@ impl<A: Actor> ProxyFor<A> {
         result.await.map_err(Into::into)
     }
 
-    pub async fn stop(&mut self) -> Result<(), MessageError> {
-        self.sink
-            .send(Envelope::Stop)
-            .await
-            .map_err::<MessageError, _>(Into::into)
-    }
-
     pub(crate) fn count(&self) -> usize {
         Arc::strong_count(self.proxy_count.as_ref().unwrap())
     }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -2,20 +2,37 @@ use crate::{
     stage::{ActorState, ProxyFor},
     Actor, ActorProxy,
 };
-use std::sync::{atomic::AtomicU8, Arc};
+use std::{
+    convert::TryInto,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    },
+};
 
 /// Remote controller for an actor to manage its own state.
 #[derive(Debug)]
 pub struct Remote<A: Actor> {
-    inner: Arc<RemoteInner>,
-    proxy: ProxyFor<A>,
+    pub(crate) inner: Arc<RemoteInner>,
+    pub(crate) proxy: ProxyFor<A>,
 }
 
 impl<A: Actor> Remote<A> {
     pub fn proxy(&self) -> A::Proxy {
         A::Proxy::new(self.proxy.clone())
     }
+
+    pub fn stop(&self) -> Result<(), StopError> {
+        unimplemented!()
+    }
+
+    pub fn state(&self) -> ActorState {
+        self.inner.state()
+    }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct StopError;
 
 #[derive(Debug)]
 pub(crate) struct RemoteInner {
@@ -25,11 +42,21 @@ pub(crate) struct RemoteInner {
 impl RemoteInner {
     pub(crate) fn new(state: ActorState) -> Self {
         Self {
-            state: AtomicU8::new(state as u8),
+            state: AtomicU8::new(state.into()),
         }
     }
 
     pub(crate) fn set_state(&self, state: ActorState) -> ActorState {
-        self.state.swap(state as u8) as ActorState
+        self.state
+            .swap(state as u8, Ordering::SeqCst)
+            .try_into()
+            .expect("Failed to convert raw actor state")
+    }
+
+    pub(crate) fn state(&self) -> ActorState {
+        self.state
+            .load(Ordering::SeqCst)
+            .try_into()
+            .expect("Failed to convert raw actor state")
     }
 }

--- a/src/remote.rs
+++ b/src/remote.rs
@@ -1,0 +1,35 @@
+use crate::{
+    stage::{ActorState, ProxyFor},
+    Actor, ActorProxy,
+};
+use std::sync::{atomic::AtomicU8, Arc};
+
+/// Remote controller for an actor to manage its own state.
+#[derive(Debug)]
+pub struct Remote<A: Actor> {
+    inner: Arc<RemoteInner>,
+    proxy: ProxyFor<A>,
+}
+
+impl<A: Actor> Remote<A> {
+    pub fn proxy(&self) -> A::Proxy {
+        A::Proxy::new(self.proxy.clone())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RemoteInner {
+    state: AtomicU8,
+}
+
+impl RemoteInner {
+    pub(crate) fn new(state: ActorState) -> Self {
+        Self {
+            state: AtomicU8::new(state as u8),
+        }
+    }
+
+    pub(crate) fn set_state(&self, state: ActorState) -> ActorState {
+        self.state.swap(state as u8) as ActorState
+    }
+}

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -66,7 +66,7 @@ impl<A: Actor> StageBuilder<A> {
         }
     }
 
-    pub fn spawn(self, actor: A) -> Proxy<A> {
+    pub fn spawn(self, actor: A) -> A::Proxy {
         let stage = self.finish(actor);
         let proxy = stage.proxy();
         runtime::spawn(stage.run());

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -1,0 +1,123 @@
+use crate::{envelope::*, message::*, Actor, MessageError};
+use derivative::Derivative;
+use futures::{
+    channel::{mpsc, oneshot},
+    prelude::*,
+};
+use log::*;
+use std::{
+    marker::PhantomData,
+    sync::{atomic::AtomicU8, Arc},
+};
+
+pub struct StageBuilder<A: Actor> {
+    remote: Arc<RemoteInner>,
+    _marker: PhantomData<A>,
+}
+
+impl<A: Actor> StageBuilder<A> {
+    pub fn new() -> (Self, Remote<A>) {
+        unimplemented!()
+    }
+
+    pub fn finish(actor: A) -> Stage<A> {
+        unimplemented!()
+    }
+}
+
+pub struct Stage<A: Actor> {
+    actor: A,
+    stream: mpsc::Receiver<Envelope<A>>,
+
+    /// Share a reference to the `RemoteInner` so that we can check the state.
+    remote: Arc<RemoteInner>,
+}
+
+impl<A: Actor> Stage<A> {
+    /// Consumes the stage, returning a future tha will run the actor until it is stopped.
+    pub async fn run(mut self) {
+        while let Some(envelope) = self.stream.next().await {
+            match envelope {
+                Envelope::Sync(message) => message.handle(&mut self.actor),
+                Envelope::Async(message) => message.handle(&mut self.actor).await,
+            }
+        }
+    }
+}
+
+pub trait ActorProxy: Sized + Clone {
+    type Actor: Actor<Proxy = Self>;
+
+    fn new(inner: ProxyFor<Self::Actor>) -> Self;
+}
+
+#[derive(Derivative)]
+#[derivative(Debug(bound = ""), Clone(bound = ""))]
+pub struct ProxyFor<A: Actor> {
+    sink: mpsc::Sender<Envelope<A>>,
+    proxy_count: Arc<()>,
+}
+
+impl<A: Actor> ProxyFor<A> {
+    pub async fn send_sync<M: SyncMessage<Actor = A>>(
+        &mut self,
+        message: M,
+    ) -> Result<M::Result, MessageError> {
+        let (result_sender, result) = oneshot::channel();
+        let erased_message = Box::new(SyncEnvelope {
+            message,
+            result_sender,
+        });
+        let envelope = Envelope::Sync(erased_message);
+        self.sink
+            .send(envelope)
+            .await
+            .map_err::<MessageError, _>(Into::into)?;
+        result.await.map_err(Into::into)
+    }
+
+    pub async fn send_async<M: AsyncMessage<Actor = A>>(
+        &mut self,
+        message: M,
+    ) -> Result<M::Result, MessageError> {
+        let (result_sender, result) = oneshot::channel();
+        let erased_message = Box::new(AsyncEnvelope {
+            message,
+            result_sender,
+        });
+        let envelope = Envelope::Async(erased_message);
+        self.sink
+            .send(envelope)
+            .await
+            .map_err::<MessageError, _>(Into::into)?;
+        result.await.map_err(Into::into)
+    }
+}
+
+/// Remote controller for an actor to manage its own state.
+#[derive(Debug)]
+pub struct Remote<A: Actor> {
+    inner: Arc<RemoteInner>,
+    proxy: ProxyFor<A>,
+}
+
+impl<A: Actor> Remote<A> {
+    pub fn proxy(&self) -> A::Proxy {
+        A::Proxy::new(self.proxy.clone())
+    }
+}
+
+#[derive(Debug)]
+struct RemoteInner {
+    state: AtomicU8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum ActorState {
+    Building,
+    Built,
+    Running,
+    Stopping,
+    Stopped,
+}

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -18,7 +18,7 @@ use std::{marker::PhantomData, sync::Arc};
 /// ```
 /// use thespian::{Remote, StageBuilder};
 ///
-/// struct MyActor {
+/// pub struct MyActor {
 ///     remote: Remote<Self>
 /// }
 ///
@@ -102,12 +102,6 @@ impl<A: Actor> Stage<A> {
                 Envelope::Sync(message) => message.handle(&mut self.actor),
                 Envelope::Async(message) => message.handle(&mut self.actor).await,
 
-                // Force the state to `Stopping` and immedately stop processing messages.
-                Envelope::Stop => {
-                    self.remote.set_state(ActorState::Stopping);
-                    break;
-                }
-
                 // NOTE: We don't need to do anything in the case that a proxy was dropped, since
                 // we check the proxy count at the end of the loop body.
                 Envelope::ProxyDropped => {}
@@ -140,10 +134,7 @@ impl<A: Actor> Stage<A> {
             match envelope {
                 Envelope::Sync(message) => message.handle(&mut self.actor),
                 Envelope::Async(message) => message.handle(&mut self.actor).await,
-
-                // NOTE: At this point we don't need to do anything for the `Stop` message, since
-                // the actor is already stopping.
-                Envelope::Stop | Envelope::ProxyDropped => {}
+                Envelope::ProxyDropped => {}
             }
         }
 

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -65,6 +65,13 @@ impl<A: Actor> StageBuilder<A> {
             remote: self.remote,
         }
     }
+
+    pub fn spawn(self, actor: A) -> Proxy<A> {
+        let stage = self.finish(actor);
+        let proxy = stage.proxy();
+        runtime::spawn(stage.run());
+        proxy
+    }
 }
 
 pub struct Stage<A: Actor> {

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -24,8 +24,7 @@ impl MyActor {
 #[runtime::test]
 async fn multiple_tasks() {
     // Spawn the actor as a concurrent task.
-    let (mut actor, context) = MyActor::default().into_context();
-    runtime::spawn(context.run());
+    let mut actor = MyActor::default().spawn();
 
     // Spawn 10 tasks, each of which will add 10 to the actor's value.
     let mut tasks = Vec::new();

--- a/tests/manual_impl.rs
+++ b/tests/manual_impl.rs
@@ -15,8 +15,7 @@ impl MyActor {
 
 #[runtime::test]
 async fn test_actor_impl() {
-    let (mut actor, context) = MyActor::default().into_context();
-    runtime::spawn(context.run());
+    let mut actor = MyActor::default().spawn();
 
     for value in 1..10 {
         let id = actor


### PR DESCRIPTION
* Add `Remote` type as a way for actors to access and update their own state.
* Replace `Context` with `Stage`.
* Add `StageBuilder` to handle multi-phase initialization of actors that need their own remote.
* Break up crate into multiple modules for cleaner organization.