### PR TITLE
Setup custom derive for Actor trait

### DIFF
--- a/examples/actor.rs
+++ b/examples/actor.rs
@@ -22,7 +22,7 @@ async fn main() {
 }
 
 // Actors are defined as normal structs.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Actor)]
 pub struct MyActor {
     count: usize,
 }

--- a/examples/remote.rs
+++ b/examples/remote.rs
@@ -24,7 +24,7 @@ async fn main() {
 }
 
 // Actors are defined as normal structs.
-#[derive(Debug)]
+#[derive(Debug, Actor)]
 pub struct MyActor {
     remote: Remote<Self>,
     count: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod remote;
 mod stage;
 
 pub use crate::{message::*, proxy::*, remote::*, stage::*};
-pub use thespian_derive::actor;
+pub use thespian_derive::*;
 
 pub trait Actor: 'static + Sized + Send {
     type Proxy: ActorProxy<Actor = Self>;

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -16,8 +16,9 @@ use std::{marker::PhantomData, sync::Arc};
 /// # Examples
 ///
 /// ```
-/// use thespian::{Remote, StageBuilder};
+/// use thespian::{Actor, Remote, StageBuilder};
 ///
+/// #[derive(Actor)]
 /// pub struct MyActor {
 ///     remote: Remote<Self>
 /// }

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -1,7 +1,7 @@
 use futures::future;
 use thespian::*;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Actor)]
 pub struct MyActor {
     id: usize,
 }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,3 +1,6 @@
+use thespian::Actor;
+
+#[derive(Debug, Actor)]
 pub struct MyActor {
     id: usize,
 }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -20,3 +20,22 @@ impl MyActor {
         unimplemented!()
     }
 }
+
+// Test that the derive works with a second impl block.
+#[thespian::actor]
+impl MyActor {
+    pub fn do_thing(&self) {
+        unimplemented!()
+    }
+}
+
+mod submodule {
+    use super::{MyActor, MyActorProxy};
+
+    #[thespian::actor]
+    impl MyActor {
+        pub fn another_thing(&self) {
+            unimplemented!()
+        }
+    }
+}


### PR DESCRIPTION
Generate the `Actor` impl and proxy using `#[derive(Actor)]` instead of generating it in the `#[actor]` attribute. This allows multiple `impl` blocks to be marked with `#[actor]`.