### PR TITLE
Remove dependency on runtime crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,19 +13,22 @@ jobs:
     - name: Install Components
       run: rustup component add rustfmt
 
-    - name: Build
+    - name: Build (no features)
       run: cargo build --verbose
 
-    - name: Run tests
+    - name: Build (async-std)
+      run: cargo build --verbose --features async-std
+
+    - name: Run tests (tokio)
       run: |
-        cargo test --verbose
+        cargo test --verbose --features tokio
         cargo fmt -- --check
 
     - name: Clippy lints
       uses: actions-rs/clippy-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-targets --all-features -- -D warnings
+        args: --all-targets --features tokio -- -D warnings
 
     - name: Check formatting
       uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,24 @@ log = "0.4.8"
 num_enum = "0.4.1"
 thespian-derive = { version = "0.1", path = "./thespian-derive" }
 thiserror = "1.0.15"
-runtime = "0.3.0-alpha.7"
+
+# Optional runtime dependencies.
+async-std = { version = "1.5.0", optional = true }
+tokio = { version = "0.2.19", features = ["rt-core"], optional = true }
+
+[dev-dependencies]
+tokio = { version = "0.2.19", features = ["full"] }
 
 [workspace]
+
+[[test]]
+name = "concurrency"
+required-features = ["tokio"]
+
+[[example]]
+name = "actor"
+required-features = ["tokio"]
+
+[[example]]
+name = "remote"
+required-features = ["tokio"]

--- a/examples/actor.rs
+++ b/examples/actor.rs
@@ -1,8 +1,8 @@
-use runtime::time::*;
 use std::time::Duration;
 use thespian::*;
+use tokio::time;
 
-#[runtime::main]
+#[tokio::main]
 async fn main() {
     // Spawn the actor as a task on the default runtime. This returns a handle to
     // the actor that we can use to communicate with it from other tasks.
@@ -36,7 +36,7 @@ impl MyActor {
     /// database.
     pub async fn add_count(&mut self, value: usize) -> usize {
         self.count += value;
-        Delay::new(Duration::from_secs(1)).await;
+        time::delay_for(Duration::from_secs(1)).await;
         self.count
     }
 }

--- a/examples/remote.rs
+++ b/examples/remote.rs
@@ -1,14 +1,14 @@
-use runtime::time::*;
 use std::time::Duration;
 use thespian::*;
+use tokio::time;
 
-#[runtime::main]
+#[tokio::main]
 async fn main() {
     let (builder, remote) = StageBuilder::new();
     let actor = MyActor { remote, count: 0 };
     let stage = builder.finish(actor);
     let mut actor = stage.proxy();
-    runtime::spawn(stage.run());
+    tokio::spawn(stage.run());
 
     // Use the handle to call the `add_count` method. Under the hood, this is using
     // channels and message passing to communicate between tasks/threads, but
@@ -38,7 +38,7 @@ impl MyActor {
     /// Adds to the actor's count, simulating a slow operation such as writing to a
     /// database.
     pub async fn add_count(&mut self, value: usize) -> usize {
-        Delay::new(Duration::from_secs(1)).await;
+        time::delay_for(Duration::from_secs(1)).await;
         self.count += value;
 
         if self.count >= 10 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@ mod proxy;
 mod remote;
 mod stage;
 
+// Helper module for abstracting over different runtimes.
+#[cfg(any(feature = "tokio", feature = "async-std"))]
+mod runtime;
+
 pub use crate::{message::*, proxy::*, remote::*, stage::*};
 pub use thespian_derive::*;
 
@@ -21,16 +25,21 @@ pub trait Actor: 'static + Sized + Send {
 
     /// Spawns the actor onto the [runtime] thread pool.
     ///
-    /// Returns the actor handle. Can only be used if the runtime has been initialized.
-    /// If not using [runtime], or if you want more control over how the actor context is
-    /// spawned, use [`into_context`] instead.
+    /// Returns the actor handle. If one of the runtime features is enabled, i.e. either
+    /// "tokio" or "async-std". If not using one of the supported runtimes, or if you
+    /// want more control over how the actor context is spawned, use [`into_context`]
+    /// instead.
     ///
     /// [runtime]: https://docs.rs/runtime
     /// [`into_context`]: #tymethod.into_context
+    #[cfg(any(feature = "tokio", feature = "async-std"))]
     fn spawn(self) -> Self::Proxy {
         let stage = self.into_stage();
         let proxy = stage.proxy();
-        runtime::spawn(stage.run());
+
+        // Spawn the actor using the selected runtime.
+        crate::runtime::spawn(stage.run());
+
         proxy
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,0 +1,17 @@
+use futures::{Future, FutureExt};
+
+#[cfg(feature = "tokio")]
+pub fn spawn<F>(future: F)
+where
+    F: Future + Send + 'static,
+{
+    tokio::spawn(future.map(|_| {}));
+}
+
+#[cfg(feature = "async-std")]
+pub fn spawn<F>(future: F)
+where
+    F: Future + Send + 'static,
+{
+    async_std::task::spawn(future.map(|_| {}));
+}

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -67,10 +67,11 @@ impl<A: Actor> StageBuilder<A> {
         }
     }
 
+    #[cfg(any(feature = "tokio", feature = "async-std"))]
     pub fn spawn(self, actor: A) -> A::Proxy {
         let stage = self.finish(actor);
         let proxy = stage.proxy();
-        runtime::spawn(stage.run());
+        crate::runtime::spawn(stage.run());
         proxy
     }
 }

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -21,7 +21,7 @@ impl MyActor {
 // Test having multiple tasks communicate with an actor concurrently. This uses the
 // default runtime implementation, which is a threadpool, so it also tests threading
 // support.
-#[runtime::test]
+#[tokio::test]
 async fn multiple_tasks() {
     // Spawn the actor as a concurrent task.
     let mut actor = MyActor::default().spawn();
@@ -30,7 +30,7 @@ async fn multiple_tasks() {
     let mut tasks = Vec::new();
     for _ in 0..10 {
         let mut actor = actor.clone();
-        let join_handle = runtime::spawn(async move {
+        let join_handle = tokio::spawn(async move {
             for _ in 0..10 {
                 actor
                     .add_id(1)

--- a/tests/manual_impl.rs
+++ b/tests/manual_impl.rs
@@ -13,7 +13,8 @@ impl MyActor {
     }
 }
 
-#[runtime::test]
+#[cfg(feature = "tokio")]
+#[tokio::test]
 async fn test_actor_impl() {
     let mut actor = MyActor::default().spawn();
 


### PR DESCRIPTION
The [runtime](https://crates.io/crates/runtime) crate has been deprecated since I initially built thespian, so I'm removing it as a dependency. Instead, I'm adding optional features for supporting [tokio](https://crates.io/crates/tokio) and [async-std](https://crates.io/crates/async-std) directly. Tests have been rewritten to use tokio as the runtime.