### PR TITLE
Deadlock improvements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,6 @@ jobs:
       - name: Run tests (tokio)
         run: |
           cargo test --verbose --features tokio
-          cargo fmt -- --check
 
       - name: Clippy lints
         uses: actions-rs/clippy-check@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,36 +4,33 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Install Components
-      run: rustup component add rustfmt
+      - name: Install Components
+        run: rustup component add rustfmt
 
-    - name: Build (no features)
-      run: cargo build --verbose
+      - name: Build (no features)
+        run: cargo build --verbose
 
-    - name: Build (async-std)
-      run: cargo build --verbose --features async-std
+      - name: Build (async-std)
+        run: cargo build --verbose --features async-std
 
-    - name: Run tests (tokio)
-      run: |
-        cargo test --verbose --features tokio
-        cargo fmt -- --check
+      - name: Run tests (tokio)
+        run: |
+          cargo test --verbose --features tokio
+          cargo fmt -- --check
 
-    - name: Clippy lints
-      uses: actions-rs/clippy-check@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        args: --all-targets --features tokio -- -D warnings
+      - name: Clippy lints
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-targets --features tokio -- -D warnings
 
-    - name: Check formatting
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all -- --check
-      env:
-        SPATIAL_LIB_DIR: "dependencies"
+      - name: Check formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check

--- a/examples/actor.rs
+++ b/examples/actor.rs
@@ -13,10 +13,7 @@ async fn main() {
     // thespian hides those implementation details and provides a simple, await-aware
     // way to communicate with the actor.
     for _ in 0..10 {
-        let id = actor
-            .add_count(1)
-            .await
-            .expect("Failed to invoke `add_id` on actor");
+        let id = actor.add_count(1).unwrap().await;
         println!("New count: {}", id);
     }
 }

--- a/examples/remote.rs
+++ b/examples/remote.rs
@@ -15,10 +15,7 @@ async fn main() {
     // thespian hides those implementation details and provides a simple, await-aware
     // way to communicate with the actor.
     for _ in 0..10 {
-        let id = actor
-            .add_count(1)
-            .await
-            .expect("Failed to invoke `add_id` on actor");
+        let id = actor.add_count(1).unwrap().await;
         println!("New count: {}", id);
     }
 }

--- a/expanded.rs
+++ b/expanded.rs
@@ -1,0 +1,101 @@
+#![feature(prelude_import)]
+#![allow(clippy::blacklisted_name)]
+#[prelude_import]
+use std::prelude::v1::*;
+#[macro_use]
+extern crate std;
+use thespian::Actor;
+pub struct MyActor {
+    id: usize,
+}
+#[automatically_derived]
+#[allow(unused_qualifications)]
+impl ::core::fmt::Debug for MyActor {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        match *self {
+            MyActor { id: ref __self_0_0 } => {
+                let mut debug_trait_builder = f.debug_struct("MyActor");
+                let _ = debug_trait_builder.field("id", &&(*__self_0_0));
+                debug_trait_builder.finish()
+            }
+        }
+    }
+}
+impl thespian::Actor for MyActor {
+    type Proxy = MyActorProxy;
+}
+pub struct MyActorProxy {
+    inner: thespian::ProxyFor<MyActor>,
+}
+#[automatically_derived]
+#[allow(unused_qualifications)]
+impl ::core::fmt::Debug for MyActorProxy {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+        match *self {
+            MyActorProxy {
+                inner: ref __self_0_0,
+            } => {
+                let mut debug_trait_builder = f.debug_struct("MyActorProxy");
+                let _ = debug_trait_builder.field("inner", &&(*__self_0_0));
+                debug_trait_builder.finish()
+            }
+        }
+    }
+}
+#[automatically_derived]
+#[allow(unused_qualifications)]
+impl ::core::clone::Clone for MyActorProxy {
+    #[inline]
+    fn clone(&self) -> MyActorProxy {
+        match *self {
+            MyActorProxy {
+                inner: ref __self_0_0,
+            } => MyActorProxy {
+                inner: ::core::clone::Clone::clone(&(*__self_0_0)),
+            },
+        }
+    }
+}
+impl thespian::ActorProxy for MyActorProxy {
+    type Actor = MyActor;
+    fn new(inner: thespian::ProxyFor<MyActor>) -> Self {
+        Self { inner }
+    }
+}
+impl MyActor {
+    pub fn multiple_params(&self, _first: usize, _second: String) {
+        {
+            ::std::rt::begin_panic("not implemented")
+        }
+    }
+}
+impl MyActorProxy {
+    pub fn multiple_params(
+        &mut self,
+        _first: usize,
+        _second: String,
+    ) -> thespian::Result<impl std::future::Future<Output = ()>> {
+        self.inner
+            .send_message(MyActor__multiple_params(_first, _second))
+    }
+}
+#[doc(hidden)]
+#[allow(bad_style)]
+pub struct MyActor__multiple_params(usize, String);
+impl thespian::Message for MyActor__multiple_params {
+    type Actor = MyActor;
+    type Output = ();
+    fn handle(
+        self,
+        actor: &mut Self::Actor,
+    ) -> thespian::futures::future::BoxFuture<'_, Self::Output> {
+        thespian::futures::future::FutureExt::boxed(
+            async move { actor.multiple_params(self.0, self.1) },
+        )
+    }
+}
+#[main]
+pub fn main() -> () {
+    extern crate test;
+    test::test_main_static(&[])
+}

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -27,7 +27,11 @@ impl<A: Actor> fmt::Debug for Envelope<A> {
 
 impl<M: Message> ErasedMessage<M::Actor> for M {
     fn handle(self: Box<Self>, actor: &mut M::Actor) -> BoxFuture<'_, ()> {
-        self.handle(actor).boxed()
+        // TODO: Remove the extra boxing here. In theory, we should be able to constrain
+        // this impl to only messages where `Output == ()`, but that's not currently
+        // supported. See https://github.com/rust-lang/rust/issues/20041 for more
+        // information.
+        Message::handle(*self, actor).map(|_| {}).boxed()
     }
 }
 

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -7,57 +7,45 @@
 //! * The message must be bundled with oneshot channel in order to send the message
 //!   response back to the sender.
 
-use crate::{Actor, AsyncErasedMessage, AsyncMessage, SyncErasedMessage, SyncMessage};
+use crate::{Actor, ErasedMessage, Message, Request};
 use futures::{channel::oneshot, future::BoxFuture, prelude::*};
 use std::fmt;
 
 pub(crate) enum Envelope<A: Actor> {
-    Sync(Box<dyn SyncErasedMessage<A>>),
-    Async(Box<dyn AsyncErasedMessage<A>>),
+    Message(Box<dyn ErasedMessage<A>>),
     ProxyDropped,
 }
 
 impl<A: Actor> fmt::Debug for Envelope<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Envelope::Sync(..) => write!(f, "Envelope::Sync"),
-            Envelope::Async(..) => write!(f, "Envelope::Async"),
+            Envelope::Message(..) => write!(f, "Envelope::Message"),
             Envelope::ProxyDropped => write!(f, "Envelope::ProxyDropped"),
         }
     }
 }
 
-pub(crate) struct SyncEnvelope<M: SyncMessage> {
-    pub(crate) result_sender: oneshot::Sender<M::Result>,
-    pub(crate) message: M,
-}
-
-impl<M: SyncMessage> SyncErasedMessage<M::Actor> for SyncEnvelope<M> {
-    fn handle(self: Box<Self>, actor: &mut M::Actor) {
-        let result = self.message.handle(actor);
-
-        // If the message sender has dropped the handle the attempt to send the result will
-        // fail. In that cases, there's nothing we can reasonably do other than discard the
-        // result.
-        let _ = self.result_sender.send(result);
+impl<M: Message> ErasedMessage<M::Actor> for M {
+    fn handle(self: Box<Self>, actor: &mut M::Actor) -> BoxFuture<'_, ()> {
+        self.handle(actor).boxed()
     }
 }
 
-pub(crate) struct AsyncEnvelope<M: AsyncMessage> {
+pub(crate) struct RequestEnvelope<M: Request> {
     pub(crate) result_sender: oneshot::Sender<M::Result>,
     pub(crate) message: M,
 }
 
-impl<M: AsyncMessage> AsyncErasedMessage<M::Actor> for AsyncEnvelope<M> {
+impl<M: Request> ErasedMessage<M::Actor> for RequestEnvelope<M> {
     fn handle(self: Box<Self>, actor: &mut M::Actor) -> BoxFuture<'_, ()> {
-        let fut = async move {
+        async move {
             let result = self.message.handle(actor).await;
 
             // If the message sender has dropped the handle the attempt to send the result will
             // fail. In that cases, there's nothing we can reasonably do other than discard the
             // result.
             let _ = self.result_sender.send(result);
-        };
-        fut.boxed()
+        }
+        .boxed()
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -7,7 +7,7 @@
 //! * The message must be bundled with oneshot channel in order to send the message
 //!   response back to the sender.
 
-use crate::{Actor, ErasedMessage, Message, Request};
+use crate::{Actor, ErasedMessage, Message};
 use futures::{channel::oneshot, future::BoxFuture, prelude::*};
 use std::fmt;
 
@@ -31,12 +31,12 @@ impl<M: Message> ErasedMessage<M::Actor> for M {
     }
 }
 
-pub(crate) struct RequestEnvelope<M: Request> {
-    pub(crate) result_sender: oneshot::Sender<M::Result>,
+pub(crate) struct RequestEnvelope<M: Message> {
+    pub(crate) result_sender: oneshot::Sender<M::Output>,
     pub(crate) message: M,
 }
 
-impl<M: Request> ErasedMessage<M::Actor> for RequestEnvelope<M> {
+impl<M: Message> ErasedMessage<M::Actor> for RequestEnvelope<M> {
     fn handle(self: Box<Self>, actor: &mut M::Actor) -> BoxFuture<'_, ()> {
         async move {
             let result = self.message.handle(actor).await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,12 @@ mod stage;
 #[cfg(any(feature = "tokio", feature = "async-std"))]
 mod runtime;
 
+// Re-export the futures crate so that it can be referenced by the generated code.
+// We don't want this to be part of the crate's stable API, though, so we hide it in
+// the generated docs.
+#[doc(hidden)]
+pub use futures;
+
 pub use crate::{message::*, proxy::*, remote::*, stage::*};
 pub use thespian_derive::*;
 
@@ -43,6 +49,8 @@ pub trait Actor: 'static + Sized + Send {
         proxy
     }
 }
+
+pub type Result<T> = std::result::Result<T, MessageError>;
 
 #[derive(Debug, Clone, Error)]
 #[error("{cause}")]

--- a/src/message.rs
+++ b/src/message.rs
@@ -3,24 +3,19 @@
 use crate::Actor;
 use futures::future::BoxFuture;
 
-pub trait SyncMessage: 'static + Sized + Send {
+pub trait Message: 'static + Sized + Send {
     type Actor: Actor;
-    type Result: Sized + Send;
 
-    fn handle(self, actor: &mut Self::Actor) -> Self::Result;
+    fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, ()>;
 }
 
-pub trait AsyncMessage: 'static + Sized + Send {
+pub trait Request: 'static + Sized + Send {
     type Actor: Actor;
     type Result: Sized + Send;
 
     fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, Self::Result>;
 }
 
-pub trait SyncErasedMessage<A: Actor>: Send {
-    fn handle(self: Box<Self>, actor: &mut A);
-}
-
-pub trait AsyncErasedMessage<A: Actor>: Send {
+pub trait ErasedMessage<A: Actor>: Send {
     fn handle(self: Box<Self>, actor: &mut A) -> BoxFuture<'_, ()>;
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -5,15 +5,9 @@ use futures::future::BoxFuture;
 
 pub trait Message: 'static + Sized + Send {
     type Actor: Actor;
+    type Output: Sized + Send;
 
-    fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, ()>;
-}
-
-pub trait Request: 'static + Sized + Send {
-    type Actor: Actor;
-    type Result: Sized + Send;
-
-    fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, Self::Result>;
+    fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, Self::Output>;
 }
 
 pub trait ErasedMessage<A: Actor>: Send {

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -56,10 +56,10 @@ impl<A: Actor> ProxyFor<A> {
     ///
     /// If the actor panics while handling the message, the panic will be propagated to
     /// any code awaiting the response.
-    pub fn send_request<R: Request<Actor = A>>(
+    pub fn send_request<R: Message<Actor = A>>(
         &mut self,
         message: R,
-    ) -> Result<impl Future<Output = R::Result>, MessageError> {
+    ) -> Result<impl Future<Output = R::Output>, MessageError> {
         let (result_sender, result) = oneshot::channel();
         let erased_message = Box::new(RequestEnvelope {
             message,

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -38,38 +38,40 @@ impl<A: Actor> ProxyFor<A> {
         }
     }
 
-    pub async fn send_sync<M: SyncMessage<Actor = A>>(
-        &mut self,
-        message: M,
-    ) -> Result<M::Result, MessageError> {
-        let (result_sender, result) = oneshot::channel();
-        let erased_message = Box::new(SyncEnvelope {
-            message,
-            result_sender,
-        });
-        let envelope = Envelope::Sync(erased_message);
-        self.sink
-            .send(envelope)
-            .await
-            .map_err::<MessageError, _>(Into::into)?;
-        result.await.map_err(Into::into)
+    /// Sends a message to an actor.
+    ///
+    /// If the actor is still running and there is space in its message queue, the
+    /// message will be enqueued synchronously. Otherwise, an error will be returned.
+    pub fn send_message<M: Message<Actor = A>>(&mut self, message: M) -> Result<(), MessageError> {
+        let erased_message = Box::new(message);
+        let envelope = Envelope::Message(erased_message);
+        self.sink.try_send(envelope).map_err(Into::into)
     }
 
-    pub async fn send_async<M: AsyncMessage<Actor = A>>(
+    /// Sends a request to an actor, returning a future yielding the actor's response.
+    ///
+    /// If the actor has stopped or its message queue is full, this method will return
+    /// an error synchronously. Otherwise, the message will be queued and the returned
+    /// future will resolve to the actor's response.
+    ///
+    /// If the actor panics while handling the message, the panic will be propagated to
+    /// any code awaiting the response.
+    pub fn send_request<R: Request<Actor = A>>(
         &mut self,
-        message: M,
-    ) -> Result<M::Result, MessageError> {
+        message: R,
+    ) -> Result<impl Future<Output = R::Result>, MessageError> {
         let (result_sender, result) = oneshot::channel();
-        let erased_message = Box::new(AsyncEnvelope {
+        let erased_message = Box::new(RequestEnvelope {
             message,
             result_sender,
         });
-        let envelope = Envelope::Async(erased_message);
-        self.sink
-            .send(envelope)
-            .await
-            .map_err::<MessageError, _>(Into::into)?;
-        result.await.map_err(Into::into)
+        let envelope = Envelope::Message(erased_message);
+        self.sink.try_send(envelope)?;
+
+        // Message was successfully enqueued. Return a future that awaits the message
+        // response and panics if the actor failed to one, since the only case where an
+        // actor wouldn't send a response is if it panics while handling the request.
+        Ok(async { result.await.expect("Actor panicked while handling message") })
     }
 
     pub(crate) fn count(&self) -> usize {
@@ -86,7 +88,7 @@ impl<A: Actor> ProxyFor<A> {
 
 impl<A: Actor> Drop for ProxyFor<A> {
     fn drop(&mut self) {
-        // Manaully drop the inner ref count in order to ensure the count has decreased
+        // Manually drop the inner ref count in order to ensure the count has decreased
         // *before* the stage receives the drop message.
         mem::drop(self.proxy_count.take());
 

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -108,8 +108,7 @@ impl<A: Actor> Stage<A> {
         // holds onto a copy of the proxy, that case should never happen right?
         while let Some(envelope) = self.receiver.next().await {
             match envelope {
-                Envelope::Sync(message) => message.handle(&mut self.actor),
-                Envelope::Async(message) => message.handle(&mut self.actor).await,
+                Envelope::Message(message) => message.handle(&mut self.actor).await,
 
                 // NOTE: We don't need to do anything in the case that a proxy was dropped, since
                 // we check the proxy count at the end of the loop body.
@@ -141,8 +140,7 @@ impl<A: Actor> Stage<A> {
         // Process any remaining messages.
         while let Some(envelope) = self.receiver.next().await {
             match envelope {
-                Envelope::Sync(message) => message.handle(&mut self.actor),
-                Envelope::Async(message) => message.handle(&mut self.actor).await,
+                Envelope::Message(message) => message.handle(&mut self.actor).await,
                 Envelope::ProxyDropped => {}
             }
         }

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -34,7 +34,7 @@ async fn multiple_tasks() {
         let mut actor = actor.clone();
         let join_handle = tokio::spawn(async move {
             for _ in 0..10 {
-                actor.add_id(1).unwrap();
+                actor.add_id(1).unwrap().await;
             }
         });
         tasks.push(join_handle);

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -21,7 +21,7 @@ impl MyActor {
 }
 
 // Test having multiple tasks communicate with an actor concurrently. This uses the
-// default runtime implementation, which is a threadpool, so it also tests threading
+// default runtime implementation, which is a thread pool, so it also tests threading
 // support.
 #[tokio::test]
 async fn multiple_tasks() {
@@ -34,18 +34,12 @@ async fn multiple_tasks() {
         let mut actor = actor.clone();
         let join_handle = tokio::spawn(async move {
             for _ in 0..10 {
-                actor
-                    .add_id(1)
-                    .await
-                    .expect("Failed to invoke `add_id` on actor");
+                actor.add_id(1).unwrap();
             }
         });
         tasks.push(join_handle);
     }
 
     future::join_all(tasks).await;
-    assert_eq!(
-        100,
-        actor.id().await.expect("Failed to invoke `id` on actor")
-    );
+    assert_eq!(100, actor.id().unwrap().await,);
 }

--- a/tests/concurrency.rs
+++ b/tests/concurrency.rs
@@ -1,32 +1,33 @@
-#![cfg(feature = "tokio")]
+#![allow(unused_imports)]
 
 use futures::future;
 use thespian::*;
 
 #[derive(Debug, Default, Actor)]
-pub struct MyActor {
-    id: usize,
+pub struct Counter {
+    value: usize,
 }
 
 #[thespian::actor]
-impl MyActor {
-    pub fn id(&self) -> usize {
-        self.id
+impl Counter {
+    pub fn value(&self) -> usize {
+        self.value
     }
 
-    pub async fn add_id(&mut self, value: usize) -> usize {
-        self.id += value;
-        self.id
+    pub async fn add(&mut self, value: usize) -> usize {
+        self.value += value;
+        self.value
     }
 }
 
 // Test having multiple tasks communicate with an actor concurrently. This uses the
 // default runtime implementation, which is a thread pool, so it also tests threading
 // support.
+#[cfg(feature = "tokio")]
 #[tokio::test]
 async fn multiple_tasks() {
     // Spawn the actor as a concurrent task.
-    let mut actor = MyActor::default().spawn();
+    let mut actor = Counter::default().spawn();
 
     // Spawn 10 tasks, each of which will add 10 to the actor's value.
     let mut tasks = Vec::new();
@@ -34,12 +35,12 @@ async fn multiple_tasks() {
         let mut actor = actor.clone();
         let join_handle = tokio::spawn(async move {
             for _ in 0..10 {
-                actor.add_id(1).unwrap().await;
+                actor.add(1).unwrap().await;
             }
         });
         tasks.push(join_handle);
     }
 
     future::join_all(tasks).await;
-    assert_eq!(100, actor.id().unwrap().await,);
+    assert_eq!(100, actor.value().unwrap().await);
 }

--- a/tests/deadlock.rs
+++ b/tests/deadlock.rs
@@ -1,0 +1,74 @@
+//! Test to verify that actors can send a message to an actor that is currently
+//! processing a message without deadlocking.
+//!
+//! This tests the issue reported in [#9]. The test defines two actors `Foo` and
+//! `Bar` that each hold on to the other's proxy. To trigger the potential deadlock
+//! `Foo` sends a message to `Bar` from within one of its message handlers, which in
+//! turn sends a message back to `Foo` while it's still processing the initial
+//! message. In the original bug, both actors were waiting for the other to finish
+//! processing their messages, leading to a deadlock.
+//!
+//! [#9]: https://github.com/randomPoison/thespian/issues/9
+
+#![allow(unused_imports)]
+
+use futures::{future, channel::oneshot};
+use thespian::*;
+use std::time::Duration;
+
+#[derive(Debug, Actor)]
+pub struct Foo {
+    bar: BarProxy,
+    result: Option<oneshot::Sender<usize>>,
+}
+
+#[thespian::actor]
+impl Foo {
+    pub async fn tell_bar(&mut self) {
+        self.bar.add_to_foo().unwrap().await;
+    }
+
+    pub fn add(&mut self, value: usize) {
+        self.result.take().unwrap().send(value).unwrap();
+    }
+}
+
+#[derive(Debug, Actor)]
+pub struct Bar {
+    value: usize,
+    foo: FooProxy,
+}
+
+#[thespian::actor]
+impl Bar {
+    pub fn add_to_foo(&mut self) -> bool {
+        self.foo.add(self.value).unwrap();
+        true
+    }
+
+    pub fn checkpoint(&self) -> () {}
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn possible_deadlock() {
+    // Define the expected value for `Foo` to send, and created the channel it will use
+    // to send it.
+    let expected = 123;
+    let (sender, receiver) = oneshot::channel();
+
+    // Create both actors, giving each one a proxy for the other.
+    let (foo_stage, foo_remote) = StageBuilder::new();
+    let (bar_stage, bar_remote) = StageBuilder::new();
+    foo_stage.spawn(Foo { result: Some(sender), bar: bar_remote.proxy() });
+    bar_stage.spawn(Bar { value: expected, foo: foo_remote.proxy() });
+
+    // Send the initial message to `Foo` to start the potential deadlock.
+    let mut foo = foo_remote.proxy();
+    foo.tell_bar().unwrap();
+
+    // Request the updated value from `foo`. If the actors have deadlocked the timeout
+    // will fire instead.
+    let actual = tokio::time::timeout(Duration::from_millis(500), receiver).await.unwrap().unwrap();
+    assert_eq!(expected, actual);
+}

--- a/tests/deadlock.rs
+++ b/tests/deadlock.rs
@@ -10,7 +10,7 @@
 //!
 //! [#9]: https://github.com/randomPoison/thespian/issues/9
 
-#![allow(unused_imports)]
+#![allow(unused_imports, clippy::blacklisted_name)]
 
 use futures::{channel::oneshot, future};
 use std::time::Duration;

--- a/tests/deadlock.rs
+++ b/tests/deadlock.rs
@@ -45,8 +45,6 @@ impl Bar {
         self.foo.add(self.value).unwrap();
         true
     }
-
-    pub fn checkpoint(&self) -> () {}
 }
 
 #[cfg(feature = "tokio")]

--- a/tests/manual_impl.rs
+++ b/tests/manual_impl.rs
@@ -48,11 +48,11 @@ pub struct MyActorProxy {
 }
 
 impl MyActorProxy {
-    pub fn add_sync(&mut self, value: usize) -> Result<impl Future<Output = usize>, MessageError> {
+    pub fn add_sync(&mut self, value: usize) -> thespian::Result<impl Future<Output = usize>> {
         self.inner.send_request(MyActor__add_sync(value))
     }
 
-    pub fn add_async(&mut self, value: usize) -> Result<impl Future<Output = usize>, MessageError> {
+    pub fn add_async(&mut self, value: usize) -> thespian::Result<impl Future<Output = usize>> {
         self.inner.send_request(MyActor__add_async(value))
     }
 }
@@ -69,11 +69,11 @@ impl ActorProxy for MyActorProxy {
 #[allow(bad_style)]
 struct MyActor__add_sync(usize);
 
-impl Request for MyActor__add_sync {
+impl Message for MyActor__add_sync {
     type Actor = MyActor;
-    type Result = usize;
+    type Output = usize;
 
-    fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, Self::Result> {
+    fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, Self::Output> {
         futures::future::ready(actor.add_sync(self.0)).boxed()
     }
 }
@@ -82,11 +82,11 @@ impl Request for MyActor__add_sync {
 #[allow(bad_style)]
 struct MyActor__add_async(usize);
 
-impl Request for MyActor__add_async {
+impl Message for MyActor__add_async {
     type Actor = MyActor;
-    type Result = usize;
+    type Output = usize;
 
-    fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, Self::Result> {
+    fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, Self::Output> {
         actor.add_async(self.0).boxed()
     }
 }
@@ -97,6 +97,7 @@ struct MyActor__add(usize);
 
 impl Message for MyActor__add {
     type Actor = MyActor;
+    type Output = ();
 
     fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, ()> {
         futures::future::ready(actor.add(self.0)).boxed()

--- a/tests/manual_impl.rs
+++ b/tests/manual_impl.rs
@@ -3,13 +3,23 @@ use thespian::*;
 
 #[derive(Debug, Default)]
 pub struct MyActor {
-    id: usize,
+    value: usize,
 }
 
+// #[thespian::actor]
 impl MyActor {
-    pub async fn add_id(&mut self, value: usize) -> usize {
-        self.id += value;
-        self.id
+    pub async fn add_async(&mut self, value: usize) -> usize {
+        self.value += value;
+        self.value
+    }
+
+    pub fn add_sync(&mut self, value: usize) -> usize {
+        self.value += value;
+        self.value
+    }
+
+    pub fn add(&mut self, value: usize) {
+        self.value += value;
     }
 }
 
@@ -19,11 +29,8 @@ async fn test_actor_impl() {
     let mut actor = MyActor::default().spawn();
 
     for value in 1..10 {
-        let id = actor
-            .add_id(1)
-            .await
-            .expect("Failed to invoke `add_id` on actor");
-        assert_eq!(id, value);
+        let result = actor.add_sync(1).unwrap().await;
+        assert_eq!(value, result);
     }
 }
 
@@ -41,8 +48,12 @@ pub struct MyActorProxy {
 }
 
 impl MyActorProxy {
-    pub async fn add_id(&mut self, value: usize) -> Result<usize, MessageError> {
-        self.inner.send_async(MyActor__add_id(value)).await
+    pub fn add_sync(&mut self, value: usize) -> Result<impl Future<Output = usize>, MessageError> {
+        self.inner.send_request(MyActor__add_sync(value))
+    }
+
+    pub fn add_async(&mut self, value: usize) -> Result<impl Future<Output = usize>, MessageError> {
+        self.inner.send_request(MyActor__add_async(value))
     }
 }
 
@@ -56,13 +67,38 @@ impl ActorProxy for MyActorProxy {
 
 #[derive(Debug)]
 #[allow(bad_style)]
-struct MyActor__add_id(usize);
+struct MyActor__add_sync(usize);
 
-impl AsyncMessage for MyActor__add_id {
+impl Request for MyActor__add_sync {
     type Actor = MyActor;
     type Result = usize;
 
     fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, Self::Result> {
-        actor.add_id(self.0).boxed()
+        futures::future::ready(actor.add_sync(self.0)).boxed()
+    }
+}
+
+#[derive(Debug)]
+#[allow(bad_style)]
+struct MyActor__add_async(usize);
+
+impl Request for MyActor__add_async {
+    type Actor = MyActor;
+    type Result = usize;
+
+    fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, Self::Result> {
+        actor.add_async(self.0).boxed()
+    }
+}
+
+#[derive(Debug)]
+#[allow(bad_style)]
+struct MyActor__add(usize);
+
+impl Message for MyActor__add {
+    type Actor = MyActor;
+
+    fn handle(self, actor: &mut Self::Actor) -> BoxFuture<'_, ()> {
+        futures::future::ready(actor.add(self.0)).boxed()
     }
 }


### PR DESCRIPTION
Partially addresses the issue raised in #9.

This PR makes two main changes in order to reduce the likelihood of deadlocks occurring and to provide tools for fixing deadlocks once they're discovered.

* The initial step of enqueuing a message now completes or fails synchronously. This means that code sending a message to an actor can choose to ignore the response to a message if the response isn't needed.
* Message handlers that don't return a value do not send a response. This completely removes the possibility of deadlock when sending the corresponding message.

Notably, this PR does **NOT** remove the ability to have message handlers return a response, which means that it's still possible to deadlock two (or more) actors in the manner described in #9. However, such deadlocks can now at least be resolved by not awaiting the response after sending the initial message, meaning that deadlocks can now be fixed once they're discovered.

We may want to go further and fully remove messages responses if it still proves to be too easy to cause a deadlock, however my intuition is that the feature is too useful to not support; Accomplishing the same flow with one-way message passing (as is the common approach in other actor frameworks) is cumbersome and boilerplate-heavy, which undermines the whole point of thespian. I'll continue to evaluate the state of things and gather notes in #9.